### PR TITLE
Fixes for separators and blank lines

### DIFF
--- a/md-readme.el
+++ b/md-readme.el
@@ -91,6 +91,16 @@ This function transforms the header in-place, so be sure to
 extract the header first with mdr-extract-header and call it on
 the copy."
   (goto-char (point-min))
+  ;; Replace "separator" lines of just semicolons
+  (replace-regexp "
+;;;;* *
+" "\n")
+  (goto-char (point-min))
+  ;; Collapse multiple blank comment lines to just one
+  (replace-regexp "
+\\(;; *\n\\)\\{2,\\}" "
+\\1")
+  (goto-char (point-min))
   (mdr-find-and-replace-disclaimer)
   (while (< (line-number-at-pos) (line-number-at-pos (point-max)))
     (when (looking-at ";;")


### PR DESCRIPTION
This makes a few improvements to the behavior of this package when an elisp header contains separator lines and consecutive blank lines, of the type added by the header2 library.
