### PR TITLE
Add and document bin/md-readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,12 @@ but here is one that works for me:
     (dolist (dir '("~/Projects/wpmail/" "~/Projects/md-readme/"))
       (dir-locals-set-directory-class
        dir 'generate-README-with-md-readme))
-    (add-hook 'after-save-hook 
+    (add-hook 'after-save-hook
               '(lambda () (if (boundp 'mdr-generate-readme) (mdr-generate))))
+
+# Binaries
+`bin/md-readme` is a shell script that will generate readme.md for the
+passed file. See it for usage instructions.
 
 # History
 * 2009-11:    First release.

--- a/bin/md-readme
+++ b/bin/md-readme
@@ -9,7 +9,7 @@
 # md-readme package, you can just run `cask exec md-readme <filename>`, since
 # Cask will set up the environment for you.
 
-if [[ "$#" -ne 1 ]]; then
+if [ "$#" -ne 1 ]; then
     echo "Usage: md-readme <filename>" >&2
 
     exit 2

--- a/bin/md-readme
+++ b/bin/md-readme
@@ -1,0 +1,18 @@
+#! /bin/sh
+
+# This is a script for rendering readme.md on the command-line.
+#
+# It requires md-readme.el to be on the load path. That can be done by adding
+# its containing directory to the env var EMACSLOADPATH.
+#
+# If you use [Cask](http://cask.readthedocs.org/en/latest/) to install the
+# md-readme package, you can just run `cask exec md-readme <filename>`, since
+# Cask will set up the environment for you.
+
+if [[ "$#" -ne 1 ]]; then
+    echo "Usage: md-readme <filename>" >&2
+
+    exit 2
+fi
+
+exec "$EMACS" -batch "$@" -l md-readme -f mdr-generate

--- a/md-readme.el
+++ b/md-readme.el
@@ -59,8 +59,12 @@
 ;;     (dolist (dir '("~/Projects/wpmail/" "~/Projects/md-readme/"))
 ;;       (dir-locals-set-directory-class
 ;;        dir 'generate-README-with-md-readme))
-;;     (add-hook 'after-save-hook 
+;;     (add-hook 'after-save-hook
 ;;               '(lambda () (if (boundp 'mdr-generate-readme) (mdr-generate))))
+
+;;; Binaries
+;; `bin/md-readme` is a shell script that will generate readme.md for the
+;; passed file. See it for usage instructions.
 
 ;;; History:
 ;; 2009-11:    First release.


### PR DESCRIPTION
The intention is to make life easier for Cask users depending on
md-readme.el in development environments.

It could be useful in other contexts, though.