### PR TITLE
Use non-interactive replace instead

### DIFF
--- a/md-readme.el
+++ b/md-readme.el
@@ -80,8 +80,9 @@
       (mdr-convert-header))))
 
 (defun mdr-replace-regexp (regexp replacement)
-  (while (re-search-forward regexp nil :noerror)
-    (replace-match replacement)))
+  (save-match-data
+    (while (re-search-forward regexp nil :noerror)
+      (replace-match replacement))))
 
 (defun mdr-generate-batch ()
   "Generate README.md from elisp files on the command line.

--- a/md-readme.el
+++ b/md-readme.el
@@ -79,6 +79,10 @@
       (insert header)
       (mdr-convert-header))))
 
+(defun mdr-replace-regexp (regexp replacement)
+  (while (re-search-forward regexp nil :noerror)
+    (replace-match replacement)))
+
 (defun mdr-generate-batch ()
   "Generate README.md from elisp files on the command line.
 Takes two command line arguments: the elisp filename, and the target
@@ -97,12 +101,12 @@ extract the header first with mdr-extract-header and call it on
 the copy."
   (goto-char (point-min))
   ;; Replace "separator" lines of just semicolons
-  (replace-regexp "
+  (mdr-replace-regexp "
 ;;;;* *
 " "\n")
   (goto-char (point-min))
   ;; Collapse multiple blank comment lines to just one
-  (replace-regexp "
+  (mdr-replace-regexp "
 \\(;; *\n\\)\\{2,\\}" "
 \\1")
   (goto-char (point-min))
@@ -166,7 +170,7 @@ Thus, this escaping is necessary."
 
   (save-excursion
     (goto-char (point-min))
-    (replace-regexp "`\\(\\_<.*\\_>\\)'" "`` `\\1' ``")))
+    (mdr-replace-regexp "`\\(\\_<.*\\_>\\)'" "`` `\\1' ``")))
 
 (provide 'md-readme)
 ;;; md-readme.el ends here


### PR DESCRIPTION
Thanks for the package

Using `replace-regexp` was causing "Replaced x occurrences" messages and a slightly noticeable lag since it was made for interactive use. The documentation of `replace-regexp` recommends using `re-search-forward` and `replace-match` in Lisp code.

I've implemented the recommendation with in a helper `mdr-replace-regexp` function so it can be reused. Readme generation is instantaneous now and there are no more spurious messages in the echo area